### PR TITLE
Fix DECFLOAT values with 16-31 decimal places (SignSpecialPlaces mask $2f -> $3f)

### DIFF
--- a/client/3.0/FB30ClientAPI.pas
+++ b/client/3.0/FB30ClientAPI.pas
@@ -710,7 +710,7 @@ var DecFloat16: IDecFloat16;
 begin
   inherited SQLDecFloatEncode(aValue, SQLType, bufptr);
   sign := (aValue.SignSpecialPlaces and $80) shr 7;
-  exp := -(aValue.SignSpecialPlaces and $2f);
+  exp := -(aValue.SignSpecialPlaces and $3f);
 
   case SQLType of
   SQL_DEC16:
@@ -797,7 +797,7 @@ begin
   else
     IBError(ibxeInvalidDataConversion,[]);
   end;
-  Result.SignSpecialPlaces :=  (-exp and $2f);
+  Result.SignSpecialPlaces :=  (-exp and $3f);
   if sign <> 0 then
     Result.SignSpecialPlaces := Result.SignSpecialPlaces or $80;
 end;


### PR DESCRIPTION
Fixes #3.

`TBCD.SignSpecialPlaces` keeps the decimal-places count in bits 0..5 and the sign in bit 7, so the places mask must be `$3f`. Both DECFLOAT conversion paths in `TFB30ClientAPI` masked with `$2f`, dropping bit 4 — any value with 16..31 decimal places lost exactly 16 places (i.e. arrived multiplied by 10^16) on both the `GetAsBCD` read path (`SQLDecFloatDecode`) and the `AsBCD` parameter path (`SQLDecFloatEncode`). Values with 0..15 or 32..34 places were unaffected, which is how the bug stayed hidden.

The change is the two masks only (the third `$2f` in the file is inside a commented-out debug `writeln` and was left alone).

**Verification** (Firebird 6.0, LI-T6.0.0.2076, Linux aarch64, fpc 3.2.2): round trips at 8, 15, 16, 17, 22, 31 and 33 decimal places, decode via `GetAsBCD`+`BCDToStr` and encode via `SQLParams[].AsBCD` + server-side `CAST(? AS VARCHAR(60))`. Before: the 16/17/22/31-place cases all came back shifted (`1.2345678901234567` → `12345678901234567`). After: all fourteen round trips are exact, and the previously-correct cases are unchanged. Issue #3 has the full before/after table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
