### PR TITLE
Decode the transaction-marker DB info items (tags 104-107) as integers

### DIFF
--- a/client/FBOutputBlock.pas
+++ b/client/FBOutputBlock.pas
@@ -1064,6 +1064,14 @@ begin
     fb_info_conn_flags:
       FItems[index] := AddIntegerItem(P);
 
+    {transaction markers can be 4 or 8 bytes (48-bit transaction ids),
+     so they are added as variable length integers}
+    isc_info_oldest_transaction,
+    isc_info_oldest_active,
+    isc_info_oldest_snapshot,
+    isc_info_next_transaction:
+      FItems[index] := AddIntegerItem(P,dtInteger);
+
     isc_info_implementation,
     isc_info_base_level:
       FItems[index] := AddBytesItem(P);


### PR DESCRIPTION
Fixes #4.

`isc_info_oldest_transaction` / `isc_info_oldest_active` / `isc_info_oldest_snapshot` / `isc_info_next_transaction` (tags 104–107) had no case in `TDBInformation.DoParseBuffer`, so they landed in the catch-all `AddSpecialItem` branch as `dtSpecial` items — a type with no working accessor, making the values unreachable through `GetDBInformation` (`getAsInteger` and even `GetAsBytes` raise `Invalid Request for Output Block Type`).

This adds the four tags as **variable-length** integer items (`AddIntegerItem(P, dtInteger)`), which decodes with the clumplet-declared length — the markers are 4-byte values today but can be 8 bytes with 48-bit transaction ids, and `dtInteger` handles both, unlike `dtIntegerFixed`.

**Verification** (Firebird 6.0, LI-T6.0.0.2076, Linux aarch64, fpc 3.2.2): `GetDBInformation([104,105,106,107, isc_info_page_size])` now yields `OIT=921, OAT=922, OST=922, Next=922, page_size=8192` via `getAsInteger`, where every accessor raised before; the page-size item confirms neighbouring items still parse identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
