### PR TITLE
Fix use-after-free when ending a transaction with registered users

### DIFF
--- a/client/FBTransaction.pas
+++ b/client/FBTransaction.pas
@@ -330,7 +330,17 @@ procedure TFBTransaction.DoDefaultTransactionEnd(Force: boolean);
 var i: integer;
     intf: IUnknown;
     user: ITransactionUser;
+    SelfRef: ITransaction;
 begin
+  {A transaction user's TransactionEnding may release the last interface
+   reference to this transaction, which would free it while this method is
+   still running and leave the Commit/Rollback below operating on a destroyed
+   object. TFB30TimeZoneServices does exactly that: it starts an internal
+   transaction for the time zone lookups, registers itself on it, and clears
+   its own reference in TransactionEnding. Nothing else holds one - the
+   interface list stores raw object pointers, not counted references - so the
+   object went away mid-call. Hold a reference for the duration.}
+  SelfRef := self;
   if InTransaction and not FForeignHandle then
   begin
     for i := 0 to InterfaceCount - 1 do


### PR DESCRIPTION
Reading a `WITH TIME ZONE` column and then disconnecting raises
`EObjectCheck: Object reference is Nil` from inside
`TFBTransaction.DoDefaultTransactionEnd`, reached via
`TFBAttachment.EndAllTransactions` during `Disconnect`.

### Cause

Reading a time zone value creates `TFB30TimeZoneServices`, which starts an
internal transaction for the `rdb$time_zone_util` lookups and registers itself
on it:

```pascal
FTransaction := FAttachment.StartTransaction([...], taCommit);
(FTransaction as TFBTransaction).AddObject(self);
```

At disconnect, `EndAllTransactions` calls `DoDefaultTransactionEnd` on that
transaction. Its loop calls `TransactionEnding` on each registered user, and
the time zone services clears its own reference:

```pascal
(FTransaction as TFBTransaction).Remove(self);
FTransaction := nil;
```

`TInterfaceOwner` stores raw `TInterfacedObject` pointers rather than counted
references, and `EndAllTransactions` iterates them without taking one, so that
was the last reference to the transaction. The object is destroyed while
`DoDefaultTransactionEnd` is still executing, and the `Commit(Force)` at the
end of that same method then runs on freed memory.

### Fix

Hold an `ITransaction` reference to `self` for the duration of the method, so a
user's `TransactionEnding` cannot destroy the transaction out from under the
`Commit`/`Rollback` that follows.

### Reproduction

Against Firebird 6.0.0, with a table holding an integer, a plain `TIMESTAMP`,
a `TIMESTAMP WITH TIME ZONE` and a `TIME WITH TIME ZONE`; each case opens one
`TIBQuery`, closes it, commits, then disconnects:

| selected column | before | after |
| --- | --- | --- |
| `integer` | disconnects cleanly | disconnects cleanly |
| `TIMESTAMP` | disconnects cleanly | disconnects cleanly |
| `TIMESTAMP WITH TIME ZONE` | `EObjectCheck` | disconnects cleanly |
| `TIME WITH TIME ZONE` | `EObjectCheck` | disconnects cleanly |

It is not schema qualification, not the prepared statement (unpreparing first
does not help), and not global temporary tables; freeing the query and the
transaction before disconnecting does not help either, which is what pointed at
the attachment rather than the query.

Found while adding Firebird 4/5/6 support to Marathon, where it also surfaced
through the profiler: `PLG$PROF_SESSIONS` has `TIMESTAMP WITH TIME ZONE`
columns, so reading it made the following disconnect fault.
