### PR TITLE
Add the Firebird 5 service parameter constants for parallel workers and in-place ODS upgrade

### DIFF
--- a/client/include/consts_pub.inc
+++ b/client/include/consts_pub.inc
@@ -522,6 +522,9 @@
     isc_spb_rpr_ignore_checksum = $20;    
     isc_spb_rpr_kill_shadows = $40;    
     isc_spb_rpr_full = $80;    
+    {Firebird 5: upgrade the on-disk structure in place, as gfix -upgrade does.
+     Value from firebird/impl/consts_pub.h.}
+    isc_spb_rpr_upgrade_db = $1000;    
     isc_spb_rpr_icu = $0800;    
   {****************************************
    * Parameters for isc_action_svc_restore *

--- a/client/include/consts_pub.inc
+++ b/client/include/consts_pub.inc
@@ -421,6 +421,9 @@
     isc_spb_bkp_skip_data = 8;    
     isc_spb_bkp_stat = 15;    
     isc_spb_bkp_keyholder = 16;    
+    {Firebird 5: number of parallel workers for backup and restore. Values
+     from firebird/impl/consts_pub.h.}
+    isc_spb_bkp_parallel_workers = 21;    
     isc_spb_bkp_keyname = 17;    
     isc_spb_bkp_crypt = 18;    
     isc_spb_bkp_include_data = 19;    
@@ -532,6 +535,7 @@
     isc_spb_res_fix_fss_data = 13;    
     isc_spb_res_fix_fss_metadata = 14;    
     isc_spb_res_keyholder = isc_spb_bkp_keyholder;    
+    isc_spb_res_parallel_workers = isc_spb_bkp_parallel_workers;    
     isc_spb_res_keyname = isc_spb_bkp_keyname;    
     isc_spb_res_crypt = isc_spb_bkp_crypt;    
     isc_spb_res_stat = isc_spb_bkp_stat;    


### PR DESCRIPTION
`gbak -par` / `gfix` style parallel workers cannot be requested through this
library, because the service parameter block constants for it are missing.

Firebird's own `firebird/impl/consts_pub.h` has:

```c
#define isc_spb_bkp_parallel_workers	 21
#define isc_spb_res_parallel_workers	isc_spb_bkp_parallel_workers
```

`client/include/consts_pub.inc` predates Firebird 5 and carries neither, so
there is no way to add the parameter to a backup or restore request.

This adds both, with the values taken from the header shipped with Firebird
6.0.0 rather than transcribed from documentation.

### Verified

Against a live Firebird 6.0.0 server, by adding the parameter to a backup
request through `TIBXBackupService` (an ibx4lazarus change that depends on
this one):

- with one worker the parameter is not sent, and the backup behaves as before
- with four, `isc_spb_bkp_parallel_workers = 4` is sent, the server accepts it,
  and the resulting file restores to a working database

The constants alone change no behaviour — nothing in this library sends them
yet — so this is safe on its own and is split out from the ibx4lazarus side
deliberately.
